### PR TITLE
chore: upgrade tkms to support post quantum user decryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.1.0-3",
+  "version": "0.1.0-4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zama-fhe/relayer-sdk",
-      "version": "0.1.0-3",
+      "version": "0.1.0-4",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "fetch-retry": "^6.0.0",
         "keccak": "^3.0.4",
         "node-tfhe": "^1.1.2",
-        "node-tkms": "0.11.0-rc15",
+        "node-tkms": "^0.11.0-rc17",
         "tfhe": "^1.1.2",
-        "tkms": "0.11.0-rc15",
+        "tkms": "^0.11.0-rc17",
         "wasm-feature-detect": "^1.8.0"
       },
       "bin": {
@@ -7016,10 +7016,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/node-tkms": {
-      "version": "0.11.0-rc15",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-rc15.tgz",
-      "integrity": "sha512-qjJ9fX6kUzFxII0Y3m+oDGlkw+g6pTYweoDBs0KQs8ZEqJtW6bbEkkiS18ZfK+KPdzVyKGdtxCaCS5wdUl/J2A==",
-      "license": "BSD-3-Clause-Clear"
+      "version": "0.11.0-rc17",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-rc17.tgz",
+      "integrity": "sha512-u6Ie6QwgbA5h6rtmXjGDCZrXZTvhhVDVt2KyBh4mJqntBb4qtRsjR2Wv/8nMdBdN8WBjP3dAJmOlsqtjdIdInQ=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8423,10 +8422,9 @@
       }
     },
     "node_modules/tkms": {
-      "version": "0.11.0-rc15",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-rc15.tgz",
-      "integrity": "sha512-ndjb0Kar3S4XmX5B99Bs/QJn74rm01jVYKzNiqnpZe19PCOdUPSkzStgQA6jPodRPtLf3u/ZobD+FVSK+E0DGQ==",
-      "license": "BSD-3-Clause-Clear"
+      "version": "0.11.0-rc17",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-rc17.tgz",
+      "integrity": "sha512-Imu3Ucc+Jh4iCZPTyG4kscoBmtzq6Kwqhvt9PT1iBVKYf4Sp5P5h+noxoOBMJbT9yV6HlsOoPOUX/wSkL2pxwg=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -14228,9 +14226,9 @@
       "integrity": "sha512-jMCGlJKIhe3wIClsjbRndW7/Fy22ULFkJiB3hQ30MVjBiKyuUoMMetvDHDxFtKyXD57xnkHYRml9c7IU9zoNDg=="
     },
     "node-tkms": {
-      "version": "0.11.0-rc15",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-rc15.tgz",
-      "integrity": "sha512-qjJ9fX6kUzFxII0Y3m+oDGlkw+g6pTYweoDBs0KQs8ZEqJtW6bbEkkiS18ZfK+KPdzVyKGdtxCaCS5wdUl/J2A=="
+      "version": "0.11.0-rc17",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-rc17.tgz",
+      "integrity": "sha512-u6Ie6QwgbA5h6rtmXjGDCZrXZTvhhVDVt2KyBh4mJqntBb4qtRsjR2Wv/8nMdBdN8WBjP3dAJmOlsqtjdIdInQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -15199,9 +15197,9 @@
       }
     },
     "tkms": {
-      "version": "0.11.0-rc15",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-rc15.tgz",
-      "integrity": "sha512-ndjb0Kar3S4XmX5B99Bs/QJn74rm01jVYKzNiqnpZe19PCOdUPSkzStgQA6jPodRPtLf3u/ZobD+FVSK+E0DGQ=="
+      "version": "0.11.0-rc17",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-rc17.tgz",
+      "integrity": "sha512-Imu3Ucc+Jh4iCZPTyG4kscoBmtzq6Kwqhvt9PT1iBVKYf4Sp5P5h+noxoOBMJbT9yV6HlsOoPOUX/wSkL2pxwg=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.1.0-3",
+  "version": "0.1.0-4",
   "description": "fhevm Relayer SDK",
   "main": "lib/node.js",
   "types": "lib/node.d.ts",

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     "fetch-retry": "^6.0.0",
     "keccak": "^3.0.4",
     "node-tfhe": "^1.1.2",
-    "node-tkms": "0.11.0-rc15",
+    "node-tkms": "0.11.0-rc17",
     "tfhe": "^1.1.2",
-    "tkms": "0.11.0-rc15",
+    "tkms": "0.11.0-rc17",
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     "fetch-retry": "^6.0.0",
     "keccak": "^3.0.4",
     "node-tfhe": "^1.1.2",
-    "node-tkms": "0.11.0-rc17",
+    "node-tkms": "^0.11.0-rc17",
     "tfhe": "^1.1.2",
-    "tkms": "0.11.0-rc17",
+    "tkms": "^0.11.0-rc17",
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -1,9 +1,10 @@
 import { bytesToBigInt, fromHexString, toHexString } from '../utils';
 import {
-  u8vec_to_cryptobox_pk,
+  u8vec_to_ml_kem_pke_pk,
+  u8vec_to_ml_kem_pke_sk,
+  new_server_id_addr,
   new_client,
   process_user_decryption_resp_from_js,
-  u8vec_to_cryptobox_sk,
 } from 'node-tkms';
 import { ethers, getAddress } from 'ethers';
 import { DecryptedResults, checkEncryptedBits } from './decryptUtils';
@@ -183,8 +184,8 @@ export const userDecryptRequest =
     let pubKey;
     let privKey;
     try {
-      pubKey = u8vec_to_cryptobox_pk(fromHexString(publicKey));
-      privKey = u8vec_to_cryptobox_sk(fromHexString(privateKey));
+      pubKey = u8vec_to_ml_kem_pke_pk(fromHexString(publicKey));
+      privKey = u8vec_to_ml_kem_pke_sk(fromHexString(privateKey));
     } catch (e) {
       throw new Error('Invalid public or private key', { cause: e });
     }
@@ -219,7 +220,11 @@ export const userDecryptRequest =
       );
     }
 
-    const client = new_client(kmsSigners, userAddress, 'default');
+    let indexedKmsSigners = kmsSigners.map((signer, index) => {
+      return new_server_id_addr(index + 1, signer);
+    });
+
+    const client = new_client(indexedKmsSigners, userAddress, 'default');
 
     try {
       const buffer = new ArrayBuffer(32);

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -220,6 +220,7 @@ export const userDecryptRequest =
       );
     }
 
+    // assume the KMS Signers have the correct order
     let indexedKmsSigners = kmsSigners.map((signer, index) => {
       return new_server_id_addr(index + 1, signer);
     });

--- a/src/sdk/keypair.test.ts
+++ b/src/sdk/keypair.test.ts
@@ -1,28 +1,34 @@
 import { fromHexString } from '../utils';
 import { generateKeypair, createEIP712 } from './keypair';
 import {
-  cryptobox_pk_to_u8vec,
-  cryptobox_sk_to_u8vec,
-  u8vec_to_cryptobox_pk,
-  u8vec_to_cryptobox_sk,
+  ml_kem_pke_pk_to_u8vec,
+  ml_kem_pke_sk_to_u8vec,
+  u8vec_to_ml_kem_pke_pk,
+  u8vec_to_ml_kem_pke_sk,
 } from 'node-tkms';
 
 describe('token', () => {
   it('generate a valid keypair', async () => {
     const keypair = generateKeypair();
 
-    expect(keypair.publicKey.length).toBe(80);
-    expect(keypair.privateKey.length).toBe(80);
+    const ml_kem_ct_pk_length = 1568; // for MlKem1024Params
+    const ml_kem_sk_len = 3168; // for MlKem1024Params
 
-    let pkBuf = cryptobox_pk_to_u8vec(
-      u8vec_to_cryptobox_pk(fromHexString(keypair.publicKey)),
-    );
-    expect(40).toBe(pkBuf.length);
+    // note that the keypair is in hex format
+    // so the length is double the byte length
+    // due to serialization, there's an additional 8 bytes
+    expect(keypair.publicKey.length).toBe((ml_kem_ct_pk_length + 8) * 2);
+    expect(keypair.privateKey.length).toBe((ml_kem_sk_len + 8) * 2);
 
-    let skBuf = cryptobox_sk_to_u8vec(
-      u8vec_to_cryptobox_sk(fromHexString(keypair.privateKey)),
+    let pkBuf = ml_kem_pke_pk_to_u8vec(
+      u8vec_to_ml_kem_pke_pk(fromHexString(keypair.publicKey)),
     );
-    expect(40).toBe(skBuf.length);
+    expect(ml_kem_ct_pk_length + 8).toBe(pkBuf.length);
+
+    let skBuf = ml_kem_pke_sk_to_u8vec(
+      u8vec_to_ml_kem_pke_sk(fromHexString(keypair.privateKey)),
+    );
+    expect(ml_kem_sk_len + 8).toBe(skBuf.length);
   });
 
   it('create a valid EIP712', async () => {

--- a/src/sdk/keypair.ts
+++ b/src/sdk/keypair.ts
@@ -1,10 +1,10 @@
 import { isAddress } from 'ethers';
 import { toHexString } from '../utils';
 import {
-  cryptobox_keygen,
-  cryptobox_sk_to_u8vec,
-  cryptobox_pk_to_u8vec,
-  cryptobox_get_pk,
+  ml_kem_pke_keygen,
+  ml_kem_pke_sk_to_u8vec,
+  ml_kem_pke_pk_to_u8vec,
+  ml_kem_pke_get_pk,
 } from 'node-tkms';
 
 export type EIP712Type = { name: string; type: string };
@@ -142,9 +142,9 @@ export const createEIP712 =
   };
 
 export const generateKeypair = () => {
-  const keypair = cryptobox_keygen();
+  const keypair = ml_kem_pke_keygen();
   return {
-    publicKey: toHexString(cryptobox_pk_to_u8vec(cryptobox_get_pk(keypair))),
-    privateKey: toHexString(cryptobox_sk_to_u8vec(keypair)),
+    publicKey: toHexString(ml_kem_pke_pk_to_u8vec(ml_kem_pke_get_pk(keypair))),
+    privateKey: toHexString(ml_kem_pke_sk_to_u8vec(keypair)),
   };
 };


### PR DESCRIPTION
Adds support to post quantum user decryption. This will not be compatible with earlier version of kms-core (prior to v0.11.0-rc17).