### PR TITLE
feat: add api key header

### DIFF
--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -91,6 +91,7 @@ export const publicDecryptRequest =
     aclContractAddress: string,
     relayerUrl: string,
     provider: ethers.JsonRpcProvider | ethers.BrowserProvider,
+    opts?: { apiKey?: string },
   ) =>
   async (_handles: (Uint8Array | string)[]) => {
     const acl = new ethers.Contract(aclContractAddress, aclABI, provider);
@@ -142,6 +143,7 @@ export const publicDecryptRequest =
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...(opts?.apiKey && { 'x-api-key': opts.apiKey }),
       },
       body: JSON.stringify(payloadForRequest),
     };

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -95,6 +95,7 @@ export const userDecryptRequest =
     aclContractAddress: string,
     relayerUrl: string,
     provider: ethers.JsonRpcProvider | ethers.BrowserProvider,
+    opts?: { apiKey?: string },
   ) =>
   async (
     _handles: HandleContractPair[],
@@ -174,6 +175,7 @@ export const userDecryptRequest =
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...(opts?.apiKey && { 'x-api-key': opts.apiKey }),
       },
       body: JSON.stringify(payloadForRequest),
     };


### PR DESCRIPTION
It adds an optional `x-api-key` header in case the relayer expects it