### PR TITLE
http 429 + relayer error management + cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export { HandleContractPair } from './relayer/userDecrypt';
 export { PublicParams } from './sdk/encrypt';
 export { EncryptionTypes, ENCRYPTION_TYPES } from './sdk/encryptionTypes';
 export { DecryptedResults } from './relayer/decryptUtils';
+export { getErrorCauseStatus, getErrorCauseCode } from './relayer/error';
 
 export type FhevmInstance = {
   createEncryptedInput: (

--- a/src/node.ts
+++ b/src/node.ts
@@ -22,7 +22,7 @@ export {
   EIP712Type,
   SepoliaConfig,
   getErrorCauseCode,
-  getErrorCauseStatus
+  getErrorCauseStatus,
 } from './index';
 export { FhevmInstanceConfig } from './config';
 export { createTfheKeypair, createTfhePublicKey } from './tfhe';

--- a/src/node.ts
+++ b/src/node.ts
@@ -21,6 +21,8 @@ export {
   EIP712,
   EIP712Type,
   SepoliaConfig,
+  getErrorCauseCode,
+  getErrorCauseStatus
 } from './index';
 export { FhevmInstanceConfig } from './config';
 export { createTfheKeypair, createTfhePublicKey } from './tfhe';

--- a/src/relayer/error.ts
+++ b/src/relayer/error.ts
@@ -12,7 +12,7 @@ export function getErrorCauseCode(e: unknown): string | undefined {
   if (!cause || !('code' in cause) || !cause.code) {
     return undefined;
   }
-  if (typeof cause.code !== "string") {
+  if (typeof cause.code !== 'string') {
     return undefined;
   }
   return cause.code;
@@ -23,7 +23,7 @@ export function getErrorCauseStatus(e: unknown): number | undefined {
   if (!cause || !('status' in cause) || cause.status === undefined) {
     return undefined;
   }
-  if (typeof cause.status !== "number") {
+  if (typeof cause.status !== 'number') {
     return undefined;
   }
   return cause.status;
@@ -129,15 +129,17 @@ export function throwRelayerUnexpectedJSONError(
   let message: string;
   switch (operation) {
     case 'PUBLIC_DECRYPT': {
-      message = "Public decrypt failed: Relayer returned an unexpected JSON response";
+      message =
+        'Public decrypt failed: Relayer returned an unexpected JSON response';
       break;
     }
     case 'USER_DECRYPT': {
-      message = "User decrypt failed: Relayer returned an unexpected JSON response";
+      message =
+        'User decrypt failed: Relayer returned an unexpected JSON response';
       break;
     }
     default: {
-      message = "Relayer returned an unexpected JSON response";
+      message = 'Relayer returned an unexpected JSON response';
       break;
     }
   }

--- a/src/relayer/error.ts
+++ b/src/relayer/error.ts
@@ -1,0 +1,220 @@
+import { RelayerFetchResponseJson, RelayerOperation } from './fetchRelayer';
+
+export function getErrorCause(e: unknown): object | undefined {
+  if (e instanceof Error && typeof e.cause === 'object' && e.cause !== null) {
+    return e.cause;
+  }
+  return undefined;
+}
+
+export function getErrorCauseCode(e: unknown): string | undefined {
+  const cause = getErrorCause(e);
+  if (!cause || !('code' in cause) || !cause.code) {
+    return undefined;
+  }
+  if (typeof cause.code !== "string") {
+    return undefined;
+  }
+  return cause.code;
+}
+
+export function getErrorCauseStatus(e: unknown): number | undefined {
+  const cause = getErrorCause(e);
+  if (!cause || !('status' in cause) || cause.status === undefined) {
+    return undefined;
+  }
+  if (typeof cause.status !== "number") {
+    return undefined;
+  }
+  return cause.status;
+}
+
+export function getErrorCauseErrorMessage(e: unknown): string | undefined {
+  const cause = getErrorCause(e);
+  if (!cause || !('error' in cause) || !cause.error) {
+    return undefined;
+  }
+  if (cause.error instanceof Error) {
+    return cause.error.message;
+  }
+  if (
+    typeof cause.error === 'object' &&
+    'message' in cause.error &&
+    typeof cause.error.message === 'string'
+  ) {
+    return cause.error.message;
+  }
+  return undefined;
+}
+
+export async function throwRelayerResponseError(
+  operation: RelayerOperation,
+  response: Response,
+): Promise<never> {
+  let message: string;
+
+  // Special case for 429
+  if (response.status === 429) {
+    message = `Relayer rate limit exceeded: Please wait and try again later.`;
+  } else {
+    switch (operation) {
+      case 'PUBLIC_DECRYPT': {
+        message = `Public decrypt failed: relayer respond with HTTP code ${response.status}`;
+        break;
+      }
+      case 'USER_DECRYPT': {
+        message = `User decrypt failed: relayer respond with HTTP code ${response.status}`;
+        break;
+      }
+      case 'KEY_URL': {
+        message = `HTTP error! status: ${response.status}`;
+        break;
+      }
+      default: {
+        const responseText = await response.text();
+        message = `Relayer didn't response correctly. Bad status ${response.statusText}. Content: ${responseText}`;
+        break;
+      }
+    }
+  }
+
+  const cause = {
+    code: 'RELAYER_FETCH_ERROR',
+    operation,
+    status: response.status,
+    statusText: response.statusText,
+    url: response.url,
+  };
+
+  throw new Error(message, {
+    cause,
+  });
+}
+
+export function throwRelayerJSONError(
+  operation: RelayerOperation,
+  error: unknown,
+): never {
+  let message: string;
+  switch (operation) {
+    case 'PUBLIC_DECRYPT': {
+      message = "Public decrypt failed: Relayer didn't return a JSON";
+      break;
+    }
+    case 'USER_DECRYPT': {
+      message = "User decrypt failed: Relayer didn't return a JSON";
+      break;
+    }
+    default: {
+      message = "Relayer didn't return a JSON";
+      break;
+    }
+  }
+
+  const cause = {
+    code: 'RELAYER_NO_JSON_ERROR',
+    operation,
+    error,
+  };
+
+  throw new Error(message, {
+    cause,
+  });
+}
+
+export function throwRelayerUnexpectedJSONError(
+  operation: RelayerOperation,
+  error: unknown,
+): never {
+  let message: string;
+  switch (operation) {
+    case 'PUBLIC_DECRYPT': {
+      message = "Public decrypt failed: Relayer returned an unexpected JSON response";
+      break;
+    }
+    case 'USER_DECRYPT': {
+      message = "User decrypt failed: Relayer returned an unexpected JSON response";
+      break;
+    }
+    default: {
+      message = "Relayer returned an unexpected JSON response";
+      break;
+    }
+  }
+
+  const cause = {
+    code: 'RELAYER_UNEXPECTED_JSON_ERROR',
+    operation,
+    error,
+  };
+
+  throw new Error(message, {
+    cause,
+  });
+}
+
+export function throwRelayerInternalError(
+  operation: RelayerOperation,
+  json: RelayerFetchResponseJson,
+): never {
+  let message: string;
+  switch (operation) {
+    case 'PUBLIC_DECRYPT': {
+      message =
+        "Pulbic decrypt failed: the public decryption didn't succeed for an unknown reason";
+      break;
+    }
+    case 'USER_DECRYPT': {
+      message =
+        "User decrypt failed: the user decryption didn't succeed for an unknown reason";
+      break;
+    }
+    default: {
+      message = "Relayer didn't response correctly.";
+      break;
+    }
+  }
+
+  const cause = {
+    code: 'RELAYER_INTERNAL_ERROR',
+    operation,
+    error: json,
+  };
+
+  throw new Error(message, {
+    cause,
+  });
+}
+
+export function throwRelayerUnknownError(
+  operation: RelayerOperation,
+  error: unknown,
+  message?: string,
+): never {
+  if (!message) {
+    switch (operation) {
+      case 'PUBLIC_DECRYPT': {
+        message = "Public decrypt failed: Relayer didn't respond";
+        break;
+      }
+      case 'USER_DECRYPT': {
+        message = "User decrypt failed: Relayer didn't respond";
+        break;
+      }
+      default: {
+        message = "Relayer didn't response correctly. Bad JSON.";
+        break;
+      }
+    }
+  }
+
+  const cause = {
+    code: 'RELAYER_UNKNOWN_ERROR',
+    operation,
+    error,
+  };
+
+  throw new Error(message ?? "Relayer didn't response correctly.", {
+    cause,
+  });
+}

--- a/src/relayer/fetchRelayer.ts
+++ b/src/relayer/fetchRelayer.ts
@@ -122,7 +122,7 @@ export async function fetchRelayerJsonRpcPost(
   relayerOperation: RelayerOperation,
   url: string,
   payload: any,
-  options?: { apiKey?: string }
+  options?: { apiKey?: string },
 ): Promise<RelayerFetchResponseJson> {
   const init = {
     method: 'POST',

--- a/src/relayer/fetchRelayer.ts
+++ b/src/relayer/fetchRelayer.ts
@@ -1,0 +1,194 @@
+import {
+  throwRelayerUnexpectedJSONError,
+  throwRelayerJSONError,
+  throwRelayerResponseError,
+  throwRelayerUnknownError,
+} from './error';
+
+export type RelayerOperation =
+  | 'INPUT_PROOF'
+  | 'PUBLIC_DECRYPT'
+  | 'USER_DECRYPT'
+  | 'KEY_URL';
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/input_http_listener.rs#L17
+export type RelayerInputProofPayload = {
+  // Hex encoded uint256 string without prefix
+  contractChainId: `0x${string}`;
+  // Hex encoded address with 0x prefix.
+  contractAddress: `0x${string}`;
+  // Hex encoded address with 0x prefix.
+  userAddress: `0x${string}`;
+  // List of hex encoded binary proof without 0x prefix
+  ciphertextWithInputVerification: string;
+};
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/userdecrypt_http_listener.rs#L33
+export type HandleContractPairRelayer = {
+  // Hex encoded bytes32 with 0x prefix.
+  handle: `0x${string}`;
+  // Hex encoded address with 0x prefix.
+  contractAddress: `0x${string}`;
+};
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/userdecrypt_http_listener.rs#L20
+export type RelayerUserDecryptPayload = {
+  handleContractPairs: HandleContractPairRelayer[];
+  requestValidity: {
+    // Number as a string
+    startTimestamp: string;
+    // Number as a string
+    durationDays: string;
+  };
+  // Number as a string
+  contractsChainId: string;
+  // List of hex encoded addresses with 0x prefix
+  contractAddresses: `0x${string}`[];
+  // Hex encoded address with 0x prefix.
+  userAddress: `0x${string}`;
+  // Hex encoded signature without 0x prefix.
+  signature: string;
+  // Hex encoded key without 0x prefix.
+  publicKey: string;
+};
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/public_decrypt_http_listener.rs#L19
+export type RelayerPublicDecryptPayload = {
+  ciphertextHandles: `0x${string}`[];
+};
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/keyurl_http_listener.rs#L6
+type RelayerKeyData = { data_id: string; urls: Array<string> };
+type RelayerKeyInfo = { fhe_public_key: RelayerKeyData };
+export type RelayerKeyUrlResponse = {
+  response: {
+    fhe_key_info: Array<RelayerKeyInfo>;
+    crs: Record<string, RelayerKeyData>;
+  };
+};
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/userdecrypt_http_listener.rs#L64
+export type RelayerUserDecryptJsonResponse = {
+  response: Array<{
+    // Hex encoded key without 0x prefix.
+    payload: string;
+    // Hex encoded key without 0x prefix. (len=130)
+    signature: string;
+  }>;
+};
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/public_decrypt_http_listener.rs#L32
+export type RelayerPublicDecryptJsonResponse = {
+  response: Array<{
+    // Hex encoded value without 0x prefix.
+    decrypted_value: string;
+    // Hex encoded value without 0x prefix.
+    signatures: string[];
+  }>;
+};
+
+// https://github.com/zama-ai/fhevm-relayer/blob/96151ef300f787658c5fbaf1b4471263160032d5/src/http/input_http_listener.rs#L38
+export type RelayerInputProofJsonResponse = {
+  response: {
+    // Ordered List of hex encoded handles with 0x prefix.
+    handles: `0x${string}`[];
+    // Attestation signatures for Input verification for the ordered list of handles with 0x prefix.
+    signatures: `0x${string}`[];
+  };
+};
+
+export type RelayerFetchResponseJson = { response: any };
+
+function assertIsRelayerFetchResponseJson(
+  json: any,
+): asserts json is RelayerFetchResponseJson {
+  if (!json || typeof json !== 'object') {
+    throw new Error('Unexpected response JSON.');
+  }
+  if (
+    !(
+      'response' in json &&
+      json.response !== null &&
+      json.response !== undefined
+    )
+  ) {
+    throw new Error(
+      "Unexpected response JSON format: missing 'response' property.",
+    );
+  }
+}
+
+export async function fetchRelayerJsonRpcPost(
+  relayerOperation: RelayerOperation,
+  url: string,
+  payload: any,
+  options?: { apiKey?: string }
+): Promise<RelayerFetchResponseJson> {
+  const init = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options?.apiKey && { 'x-api-key': options.apiKey }),
+    },
+    body: JSON.stringify(payload),
+  };
+
+  let response: Response;
+  let json: RelayerFetchResponseJson;
+  try {
+    response = await fetch(url, init);
+  } catch (e) {
+    throwRelayerUnknownError(relayerOperation, e);
+  }
+  if (!response.ok) {
+    await throwRelayerResponseError(relayerOperation, response);
+  }
+
+  let parsed;
+  try {
+    parsed = await response.json();
+  } catch (e) {
+    throwRelayerJSONError(relayerOperation, e);
+  }
+
+  try {
+    assertIsRelayerFetchResponseJson(parsed);
+    json = parsed;
+  } catch (e) {
+    throwRelayerUnexpectedJSONError(relayerOperation, e);
+  }
+
+  return json;
+}
+
+export async function fetchRelayerGet(
+  relayerOperation: RelayerOperation,
+  url: string,
+): Promise<RelayerFetchResponseJson> {
+  let response: Response;
+  let json: RelayerFetchResponseJson;
+  try {
+    response = await fetch(url);
+  } catch (e) {
+    throwRelayerUnknownError(relayerOperation, e);
+  }
+  if (!response.ok) {
+    await throwRelayerResponseError(relayerOperation, response);
+  }
+
+  let parsed;
+  try {
+    parsed = await response.json();
+  } catch (e) {
+    throwRelayerJSONError(relayerOperation, e);
+  }
+
+  try {
+    assertIsRelayerFetchResponseJson(parsed);
+    json = parsed;
+  } catch (e) {
+    throwRelayerUnexpectedJSONError(relayerOperation, e);
+  }
+
+  return json;
+}

--- a/src/relayer/network.test.ts
+++ b/src/relayer/network.test.ts
@@ -1,15 +1,93 @@
-import { RelayerKeys, getKeysFromRelayer } from './network';
+import { getKeysFromRelayer } from './network';
 import { publicKey, publicParams } from '../test';
 import { SERIALIZED_SIZE_LIMIT_CRS, SERIALIZED_SIZE_LIMIT_PK } from '../utils';
 import fetchMock from '@fetch-mock/core';
+import { RelayerKeyUrlResponse } from './fetchRelayer';
 
-const payload: RelayerKeys = {
+// const oldPayload = {
+//   response: {
+//     crs: {
+//       '2048': {
+//         data_id: 'd8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
+//         param_choice: 1,
+//         signatures: ['0d13...', '4250...', 'a42c...', 'fhb5...'],
+//         urls: [
+//           'https://s3.amazonaws.com/bucket-name-1/PUB-p1/CRS/d8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
+//           'https://s3.amazonaws.com/bucket-name-4/PUB-p4/CRS/d8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
+//           'https://s3.amazonaws.com/bucket-name-2/PUB-p2/CRS/d8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
+//           'https://s3.amazonaws.com/bucket-name-3/PUB-p3/CRS/d8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
+//         ],
+//       },
+//     },
+//     fhe_key_info: [
+//       {
+//         fhe_public_key: {
+//           data_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//           param_choice: 1,
+//           signatures: ['cdff...', '123c...', '00ff...', 'a367...'],
+//           urls: [
+//             'https://s3.amazonaws.com/bucket-name-1/PUB-p1/PublicKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//             'https://s3.amazonaws.com/bucket-name-4/PUB-p4/PublicKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//             'https://s3.amazonaws.com/bucket-name-2/PUB-p2/PublicKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//             'https://s3.amazonaws.com/bucket-name-3/PUB-p3/PublicKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//           ],
+//         },
+//         fhe_server_key: {
+//           data_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//           param_choice: 1,
+//           signatures: ['839b...', 'baef...', '55cc...', '81a4...'],
+//           urls: [
+//             'https://s3.amazonaws.com/bucket-name-1/PUB-p1/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//             'https://s3.amazonaws.com/bucket-name-4/PUB-p4/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//             'https://s3.amazonaws.com/bucket-name-2/PUB-p2/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//             'https://s3.amazonaws.com/bucket-name-3/PUB-p3/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//           ],
+//         },
+//       },
+//     ],
+//     verf_public_key: [
+//       {
+//         key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         server_id: 1,
+//         verf_public_key_address:
+//           'https://s3.amazonaws.com/bucket-name-1/PUB-p1/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         verf_public_key_url:
+//           'https://s3.amazonaws.com/bucket-name-1/PUB-p1/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//       },
+//       {
+//         key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         server_id: 4,
+//         verf_public_key_address:
+//           'https://s3.amazonaws.com/bucket-name-4/PUB-p4/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         verf_public_key_url:
+//           'https://s3.amazonaws.com/bucket-name-4//PUB-p4/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//       },
+//       {
+//         key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         server_id: 2,
+//         verf_public_key_address:
+//           'https://s3.amazonaws.com/bucket-name-2/PUB-p2/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         verf_public_key_url:
+//           'https://s3.amazonaws.com/bucket-name-2/PUB-p2/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//       },
+//       {
+//         key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         server_id: 3,
+//         verf_public_key_address:
+//           'https://s3.amazonaws.com/bucket-name-3/PUB-p3/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//         verf_public_key_url:
+//           'https://s3.amazonaws.com/bucket-name-3/PUB-p3/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
+//       },
+//     ],
+//   },
+//   status: 'success',
+// };
+
+const payload: RelayerKeyUrlResponse = {
   response: {
     crs: {
       '2048': {
         data_id: 'd8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
-        param_choice: 1,
-        signatures: ['0d13...', '4250...', 'a42c...', 'fhb5...'],
         urls: [
           'https://s3.amazonaws.com/bucket-name-1/PUB-p1/CRS/d8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
           'https://s3.amazonaws.com/bucket-name-4/PUB-p4/CRS/d8d94eb3a23d22d3eb6b5e7b694e8afcd571d906',
@@ -22,8 +100,6 @@ const payload: RelayerKeys = {
       {
         fhe_public_key: {
           data_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-          param_choice: 1,
-          signatures: ['cdff...', '123c...', '00ff...', 'a367...'],
           urls: [
             'https://s3.amazonaws.com/bucket-name-1/PUB-p1/PublicKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
             'https://s3.amazonaws.com/bucket-name-4/PUB-p4/PublicKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
@@ -31,55 +107,9 @@ const payload: RelayerKeys = {
             'https://s3.amazonaws.com/bucket-name-3/PUB-p3/PublicKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
           ],
         },
-        fhe_server_key: {
-          data_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-          param_choice: 1,
-          signatures: ['839b...', 'baef...', '55cc...', '81a4...'],
-          urls: [
-            'https://s3.amazonaws.com/bucket-name-1/PUB-p1/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-            'https://s3.amazonaws.com/bucket-name-4/PUB-p4/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-            'https://s3.amazonaws.com/bucket-name-2/PUB-p2/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-            'https://s3.amazonaws.com/bucket-name-3/PUB-p3/ServerKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-          ],
-        },
-      },
-    ],
-    verf_public_key: [
-      {
-        key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        server_id: 1,
-        verf_public_key_address:
-          'https://s3.amazonaws.com/bucket-name-1/PUB-p1/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        verf_public_key_url:
-          'https://s3.amazonaws.com/bucket-name-1/PUB-p1/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-      },
-      {
-        key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        server_id: 4,
-        verf_public_key_address:
-          'https://s3.amazonaws.com/bucket-name-4/PUB-p4/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        verf_public_key_url:
-          'https://s3.amazonaws.com/bucket-name-4//PUB-p4/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-      },
-      {
-        key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        server_id: 2,
-        verf_public_key_address:
-          'https://s3.amazonaws.com/bucket-name-2/PUB-p2/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        verf_public_key_url:
-          'https://s3.amazonaws.com/bucket-name-2/PUB-p2/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-      },
-      {
-        key_id: '408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        server_id: 3,
-        verf_public_key_address:
-          'https://s3.amazonaws.com/bucket-name-3/PUB-p3/VerfAddress/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
-        verf_public_key_url:
-          'https://s3.amazonaws.com/bucket-name-3/PUB-p3/VerfKey/408d8cbaa51dece7f782fe04ba0b1c1d017b1088',
       },
     ],
   },
-  status: 'success',
 };
 
 fetchMock.get('https://test-relayer.net/v1/keyurl', payload);

--- a/src/relayer/network.ts
+++ b/src/relayer/network.ts
@@ -42,9 +42,12 @@ export const getKeysFromRelayer = async (
   if (keyurlCache[url]) {
     return keyurlCache[url];
   }
-  
-  const data: RelayerKeyUrlResponse = await fetchRelayerGet('KEY_URL', `${url}/v1/keyurl`);
-  
+
+  const data: RelayerKeyUrlResponse = await fetchRelayerGet(
+    'KEY_URL',
+    `${url}/v1/keyurl`,
+  );
+
   try {
     // const response = await fetch(`${url}/v1/keyurl`);
     // if (!response.ok) {
@@ -52,101 +55,101 @@ export const getKeysFromRelayer = async (
     // }
     //const data: RelayerKeys = await response.json();
     //if (data) {
-      let pubKeyUrl: string;
+    let pubKeyUrl: string;
 
-      // If no publicKeyId is provided, use the first one
-      // Warning: if there are multiple keys available, the first one will most likely never be the
-      // same between several calls (fetching the infos is non-deterministic)
-      if (!publicKeyId) {
-        pubKeyUrl = data.response.fhe_key_info[0].fhe_public_key.urls[0];
-        publicKeyId = data.response.fhe_key_info[0].fhe_public_key.data_id;
-      } else {
-        // If a publicKeyId is provided, get the corresponding info
-        const keyInfo = data.response.fhe_key_info.find(
-          (info) => info.fhe_public_key.data_id === publicKeyId,
-        );
+    // If no publicKeyId is provided, use the first one
+    // Warning: if there are multiple keys available, the first one will most likely never be the
+    // same between several calls (fetching the infos is non-deterministic)
+    if (!publicKeyId) {
+      pubKeyUrl = data.response.fhe_key_info[0].fhe_public_key.urls[0];
+      publicKeyId = data.response.fhe_key_info[0].fhe_public_key.data_id;
+    } else {
+      // If a publicKeyId is provided, get the corresponding info
+      const keyInfo = data.response.fhe_key_info.find(
+        (info) => info.fhe_public_key.data_id === publicKeyId,
+      );
 
-        if (!keyInfo) {
-          throw new Error(
-            `Could not find FHE key info with data_id ${publicKeyId}`,
-          );
-        }
-
-        // TODO: Get a given party's public key url instead of the first one
-        pubKeyUrl = keyInfo.fhe_public_key.urls[0];
-      }
-
-      const publicKeyResponse = await fetch(pubKeyUrl);
-      if (!publicKeyResponse.ok) {
+      if (!keyInfo) {
         throw new Error(
-          `HTTP error! status: ${publicKeyResponse.status} on ${publicKeyResponse.url}`,
+          `Could not find FHE key info with data_id ${publicKeyId}`,
         );
       }
 
-      let publicKey: Uint8Array;
-      if (typeof publicKeyResponse.bytes === 'function') {
-        // bytes is not widely supported yet
-        publicKey = await publicKeyResponse.bytes();
-      } else {
-        publicKey = new Uint8Array(await publicKeyResponse.arrayBuffer());
-      }
+      // TODO: Get a given party's public key url instead of the first one
+      pubKeyUrl = keyInfo.fhe_public_key.urls[0];
+    }
 
-      const publicParamsUrl = data.response.crs['2048'].urls[0];
-      const publicParamsId = data.response.crs['2048'].data_id;
+    const publicKeyResponse = await fetch(pubKeyUrl);
+    if (!publicKeyResponse.ok) {
+      throw new Error(
+        `HTTP error! status: ${publicKeyResponse.status} on ${publicKeyResponse.url}`,
+      );
+    }
 
-      const publicParams2048Response = await fetch(publicParamsUrl);
-      if (!publicParams2048Response.ok) {
-        throw new Error(
-          `HTTP error! status: ${publicParams2048Response.status} on ${publicParams2048Response.url}`,
-        );
-      }
+    let publicKey: Uint8Array;
+    if (typeof publicKeyResponse.bytes === 'function') {
+      // bytes is not widely supported yet
+      publicKey = await publicKeyResponse.bytes();
+    } else {
+      publicKey = new Uint8Array(await publicKeyResponse.arrayBuffer());
+    }
 
-      let publicParams2048: Uint8Array;
-      if (typeof publicParams2048Response.bytes === 'function') {
-        // bytes is not widely supported yet
-        publicParams2048 = await publicParams2048Response.bytes();
-      } else {
-        publicParams2048 = new Uint8Array(
-          await publicParams2048Response.arrayBuffer(),
-        );
-      }
+    const publicParamsUrl = data.response.crs['2048'].urls[0];
+    const publicParamsId = data.response.crs['2048'].data_id;
 
-      let pub_key;
-      try {
-        pub_key = TFHE.TfheCompactPublicKey.safe_deserialize(
-          publicKey,
-          SERIALIZED_SIZE_LIMIT_PK,
-        );
-      } catch (e) {
-        throw new Error('Invalid public key (deserialization failed)', {
-          cause: e,
-        });
-      }
+    const publicParams2048Response = await fetch(publicParamsUrl);
+    if (!publicParams2048Response.ok) {
+      throw new Error(
+        `HTTP error! status: ${publicParams2048Response.status} on ${publicParams2048Response.url}`,
+      );
+    }
 
-      let crs;
-      try {
-        crs = TFHE.CompactPkeCrs.safe_deserialize(
-          new Uint8Array(publicParams2048),
-          SERIALIZED_SIZE_LIMIT_CRS,
-        );
-      } catch (e) {
-        throw new Error('Invalid crs (deserialization failed)', {
-          cause: e,
-        });
-      }
+    let publicParams2048: Uint8Array;
+    if (typeof publicParams2048Response.bytes === 'function') {
+      // bytes is not widely supported yet
+      publicParams2048 = await publicParams2048Response.bytes();
+    } else {
+      publicParams2048 = new Uint8Array(
+        await publicParams2048Response.arrayBuffer(),
+      );
+    }
 
-      const result = {
-        publicKey: pub_key,
-        publicKeyId,
-        publicParams: {
-          2048: {
-            publicParams: crs,
-            publicParamsId,
-          },
+    let pub_key;
+    try {
+      pub_key = TFHE.TfheCompactPublicKey.safe_deserialize(
+        publicKey,
+        SERIALIZED_SIZE_LIMIT_PK,
+      );
+    } catch (e) {
+      throw new Error('Invalid public key (deserialization failed)', {
+        cause: e,
+      });
+    }
+
+    let crs;
+    try {
+      crs = TFHE.CompactPkeCrs.safe_deserialize(
+        new Uint8Array(publicParams2048),
+        SERIALIZED_SIZE_LIMIT_CRS,
+      );
+    } catch (e) {
+      throw new Error('Invalid crs (deserialization failed)', {
+        cause: e,
+      });
+    }
+
+    const result = {
+      publicKey: pub_key,
+      publicKeyId,
+      publicParams: {
+        2048: {
+          publicParams: crs,
+          publicParamsId,
         },
-      };
-      keyurlCache[url] = result;
-      return result;
+      },
+    };
+    keyurlCache[url] = result;
+    return result;
     // } else {
     //   throw new Error('No public key available');
     // }

--- a/src/relayer/network.ts
+++ b/src/relayer/network.ts
@@ -1,37 +1,38 @@
 import { SERIALIZED_SIZE_LIMIT_PK, SERIALIZED_SIZE_LIMIT_CRS } from '../utils';
+import { fetchRelayerGet, RelayerKeyUrlResponse } from './fetchRelayer';
 
-export type RelayerKeysItem = {
-  data_id: string;
-  param_choice: number;
-  urls: string[];
-  signatures: string[];
-};
+// export type RelayerKeysItem = {
+//   data_id: string;
+//   param_choice: number;
+//   urls: string[];
+//   signatures: string[];
+// };
 
-export type RelayerKey = {
-  data_id: string;
-  param_choice: number;
-  signatures: string[];
-  urls: string[];
-};
+// export type RelayerKey = {
+//   data_id: string;
+//   param_choice: number;
+//   signatures: string[];
+//   urls: string[];
+// };
 
-export type RelayerKeys = {
-  response: {
-    fhe_key_info: {
-      fhe_public_key: RelayerKey;
-      fhe_server_key: RelayerKey;
-    }[];
-    verf_public_key: {
-      key_id: string;
-      server_id: number;
-      verf_public_key_address: string;
-      verf_public_key_url: string;
-    }[];
-    crs: {
-      [key: string]: RelayerKeysItem;
-    };
-  };
-  status: string;
-};
+// export type RelayerKeys = {
+//   response: {
+//     fhe_key_info: {
+//       fhe_public_key: RelayerKey;
+//       fhe_server_key: RelayerKey;
+//     }[];
+//     verf_public_key: {
+//       key_id: string;
+//       server_id: number;
+//       verf_public_key_address: string;
+//       verf_public_key_url: string;
+//     }[];
+//     crs: {
+//       [key: string]: RelayerKeysItem;
+//     };
+//   };
+//   status: string;
+// };
 
 const keyurlCache: { [key: string]: any } = {};
 export const getKeysFromRelayer = async (
@@ -41,13 +42,16 @@ export const getKeysFromRelayer = async (
   if (keyurlCache[url]) {
     return keyurlCache[url];
   }
+  
+  const data: RelayerKeyUrlResponse = await fetchRelayerGet('KEY_URL', `${url}/v1/keyurl`);
+  
   try {
-    const response = await fetch(`${url}/v1/keyurl`);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    const data: RelayerKeys = await response.json();
-    if (data) {
+    // const response = await fetch(`${url}/v1/keyurl`);
+    // if (!response.ok) {
+    //   await throwRelayerResponseError("KEY_URL", response);
+    // }
+    //const data: RelayerKeys = await response.json();
+    //if (data) {
       let pubKeyUrl: string;
 
       // If no publicKeyId is provided, use the first one
@@ -143,9 +147,9 @@ export const getKeysFromRelayer = async (
       };
       keyurlCache[url] = result;
       return result;
-    } else {
-      throw new Error('No public key available');
-    }
+    // } else {
+    //   throw new Error('No public key available');
+    // }
   } catch (e) {
     throw new Error('Impossible to fetch public key: wrong relayer url.', {
       cause: e,

--- a/src/relayer/publicDecrypt.test.ts
+++ b/src/relayer/publicDecrypt.test.ts
@@ -1,22 +1,195 @@
 import { publicDecryptRequest } from './publicDecrypt';
 import fetchMock from '@fetch-mock/core';
 import { ethers } from 'ethers';
+import { fetchRelayerJsonRpcPost, RelayerPublicDecryptPayload } from './fetchRelayer';
+import { getErrorCause, getErrorCauseErrorMessage } from './error';
 
-fetchMock.post('https://test-relayer.net/v1/public-decrypt', {
-  status: 'success',
-  response: {},
-});
+const RELAYER_URL: string = 'https://test-relayer.net';
+const RELAYER_PUBLIC_DECRYPT_URL = `${RELAYER_URL}/v1/public-decrypt`;
+
+const dummyRelayerUserDecryptPayload: RelayerPublicDecryptPayload = {
+  ciphertextHandles: ['0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'],
+};
 
 describe('publicDecrypt', () => {
+  beforeEach(() => {
+    fetchMock.removeRoutes();
+  });
+
   it('get public decryption for handle', async () => {
+    fetchMock.post(RELAYER_PUBLIC_DECRYPT_URL, {
+      status: 'success',
+      response: {},
+    });
+
     publicDecryptRequest(
       [],
       1,
       54321,
       '0x8ba1f109551bd432803012645ac136ddd64dba72',
       '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
-      'https://test-relayer.net/',
+      RELAYER_URL,
       new ethers.JsonRpcProvider('https://devnet.zama.ai'),
+    );
+  });
+});
+
+describe('fetchRelayerPublicDecrypt', () => {
+  beforeEach(() => {
+    fetchMock.removeRoutes();
+  });
+
+  it('error: response.ok === false', async () => {
+    const response = new Response('Forbidden', {
+      status: 403,
+      statusText: 'Forbidden',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+
+    fetchMock.postOnce(RELAYER_PUBLIC_DECRYPT_URL, response);
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'PUBLIC_DECRYPT',
+        RELAYER_PUBLIC_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        'Error: Public decrypt failed: relayer respond with HTTP code 403',
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_FETCH_ERROR',
+        operation: 'PUBLIC_DECRYPT',
+        status: 403,
+        statusText: 'Forbidden',
+        url: RELAYER_PUBLIC_DECRYPT_URL,
+      });
+    }
+  });
+
+  it('error: response.status === 429', async () => {
+    const response = new Response('Rate Limit', {
+      status: 429,
+      statusText: 'Rate Limit',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+
+    fetchMock.postOnce(RELAYER_PUBLIC_DECRYPT_URL, response);
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'PUBLIC_DECRYPT',
+        RELAYER_PUBLIC_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        'Error: Relayer rate limit exceeded: Please wait and try again later.',
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_FETCH_ERROR',
+        operation: 'PUBLIC_DECRYPT',
+        status: 429,
+        statusText: 'Rate Limit',
+        url: RELAYER_PUBLIC_DECRYPT_URL,
+      });
+    }
+  });
+
+  it('error: fetch throws an error', async () => {
+    const errorToThrow = new Error();
+    fetchMock.postOnce(RELAYER_PUBLIC_DECRYPT_URL, {
+      throws: errorToThrow,
+    });
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'PUBLIC_DECRYPT',
+        RELAYER_PUBLIC_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        "Error: Public decrypt failed: Relayer didn't respond",
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_UNKNOWN_ERROR',
+        operation: 'PUBLIC_DECRYPT',
+        error: errorToThrow,
+      });
+    }
+  });
+
+  it('error: no json', async () => {
+    fetchMock.postOnce(RELAYER_PUBLIC_DECRYPT_URL, () => {
+      return 'DeadBeef';
+    });
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'PUBLIC_DECRYPT',
+        RELAYER_PUBLIC_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        "Error: Public decrypt failed: Relayer didn't return a JSON",
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_NO_JSON_ERROR',
+        operation: 'PUBLIC_DECRYPT',
+        error: new Error(),
+      });
+      expect(String(getErrorCauseErrorMessage(e))).toBe(
+        'Unexpected token \'D\', "DeadBeef" is not valid JSON',
+      );
+    }
+  });
+
+  it('error: unexpected json', async () => {
+    fetchMock.postOnce(RELAYER_PUBLIC_DECRYPT_URL, {
+      status: 'failure',
+      dummy: 'This is a dummy error',
+    });
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'PUBLIC_DECRYPT',
+        RELAYER_PUBLIC_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        'Error: Public decrypt failed: Relayer returned an unexpected JSON response',
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_UNEXPECTED_JSON_ERROR',
+        operation: 'PUBLIC_DECRYPT',
+        error: new Error(
+          "Unexpected response JSON format: missing 'response' property.",
+        ),
+      });
+    }
+  });
+
+  it('succeeded', async () => {
+    fetchMock.postOnce(RELAYER_PUBLIC_DECRYPT_URL, {
+      response: {},
+    });
+    await fetchRelayerJsonRpcPost(
+      'PUBLIC_DECRYPT',
+      RELAYER_PUBLIC_DECRYPT_URL,
+      dummyRelayerUserDecryptPayload,
     );
   });
 });

--- a/src/relayer/publicDecrypt.test.ts
+++ b/src/relayer/publicDecrypt.test.ts
@@ -1,7 +1,10 @@
 import { publicDecryptRequest } from './publicDecrypt';
 import fetchMock from '@fetch-mock/core';
 import { ethers } from 'ethers';
-import { fetchRelayerJsonRpcPost, RelayerPublicDecryptPayload } from './fetchRelayer';
+import {
+  fetchRelayerJsonRpcPost,
+  RelayerPublicDecryptPayload,
+} from './fetchRelayer';
 import { getErrorCause, getErrorCauseErrorMessage } from './error';
 
 const RELAYER_URL: string = 'https://test-relayer.net';

--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -1,7 +1,10 @@
 import { fromHexString, toHexString } from '../utils';
 import { ethers, AbiCoder } from 'ethers';
 import { DecryptedResults, checkEncryptedBits } from './decryptUtils';
-import { fetchRelayerJsonRpcPost, RelayerPublicDecryptPayload } from './fetchRelayer';
+import {
+  fetchRelayerJsonRpcPost,
+  RelayerPublicDecryptPayload,
+} from './fetchRelayer';
 
 const aclABI = [
   'function isAllowedForDecryption(bytes32 handle) view returns (bool)',
@@ -92,7 +95,7 @@ export const publicDecryptRequest =
     aclContractAddress: string,
     relayerUrl: string,
     provider: ethers.JsonRpcProvider | ethers.BrowserProvider,
-    options?: { apiKey?: string }
+    options?: { apiKey?: string },
   ) =>
   async (_handles: (Uint8Array | string)[]) => {
     const acl = new ethers.Contract(aclContractAddress, aclABI, provider);
@@ -132,7 +135,7 @@ export const publicDecryptRequest =
       'PUBLIC_DECRYPT',
       `${relayerUrl}/v1/public-decrypt`,
       payloadForRequest,
-      options
+      options,
     );
 
     // verify signatures on decryption:

--- a/src/relayer/sendEncryption.ts
+++ b/src/relayer/sendEncryption.ts
@@ -1,4 +1,4 @@
-import { getAddress, isAddress } from 'ethers';
+import { isAddress, getAddress as ethersGetAddress } from 'ethers';
 
 import { fromHexString, numberToHex, toHexString } from '../utils';
 import {
@@ -9,6 +9,11 @@ import { EncryptionTypes } from '../sdk/encryptionTypes';
 import { computeHandles } from './handles';
 import { ethers } from 'ethers';
 import { TFHEType } from '../tfheType';
+import { throwRelayerInternalError} from './error';
+import { fetchRelayerJsonRpcPost, RelayerFetchResponseJson, RelayerInputProofPayload } from './fetchRelayer';
+
+// Add type checking
+const getAddress = (value: string): `0x${string}` => ethersGetAddress(value) as `0x${string}`;
 
 export const currentCiphertextVersion = () => {
   return 0;
@@ -48,6 +53,22 @@ export type FhevmRelayerInputProofResponse = {
   };
   status: string;
 };
+
+function isFhevmRelayerInputProofResponse(
+  json: RelayerFetchResponseJson,
+): json is FhevmRelayerInputProofResponse {
+  const response = json.response as unknown;
+  if (typeof response !== "object" || response === null) {
+    return false;
+  }
+  if (!("handles" in response && Array.isArray(response.handles))) {
+    return false;
+  }
+  if (!("signatures" in response && Array.isArray(response.signatures))) {
+    return false;
+  }
+  return response.signatures.every((s) => typeof s === "string") && response.handles.every((h) => typeof h === "string");
+}
 
 export type RelayerEncryptedInputInternal = RelayerEncryptedInput & {
   _input: EncryptedInput;
@@ -143,49 +164,31 @@ export const createRelayerEncryptedInput =
       getBits(): EncryptionTypes[] {
         return input.getBits();
       },
-      encrypt: async (opts?: { apiKey?: string }) => {
+      encrypt: async (options?: { apiKey?: string }) => {
         const bits = input.getBits();
         const ciphertext = input.encrypt();
-        // https://github.com/zama-ai/fhevm-relayer/blob/978b08f62de060a9b50d2c6cc19fd71b5fb8d873/src/input_http_listener.rs#L13C1-L22C1
-        const payload = {
+        
+        const payload: RelayerInputProofPayload = {
           contractAddress: getAddress(contractAddress),
           userAddress: getAddress(userAddress),
           ciphertextWithInputVerification: toHexString(ciphertext),
-          contractChainId: '0x' + chainId.toString(16),
+          contractChainId: ('0x' + chainId.toString(16)) as `0x${string}`,
         };
-        const options = {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(opts?.apiKey && { 'x-api-key': opts.apiKey }),
-          },
-          body: JSON.stringify(payload),
-        };
-        const url = `${relayerUrl}/v1/input-proof`;
-        let json: FhevmRelayerInputProofResponse;
-        const response = await fetch(url, options);
-        if (!response.ok) {
-          throw new Error(
-            `Relayer didn't response correctly. Bad status ${
-              response.statusText
-            }. Content: ${await response.text()}`,
-          );
-        }
-        try {
-          json = await response.json();
-        } catch (e) {
-          throw new Error("Relayer didn't response correctly. Bad JSON.", {
-            cause: e,
-          });
+
+        const json = await fetchRelayerJsonRpcPost('INPUT_PROOF', `${relayerUrl}/v1/input-proof`, payload, options);
+
+        if (!isFhevmRelayerInputProofResponse(json)) {
+          throwRelayerInternalError("INPUT_PROOF", json);
         }
 
-        const handles = computeHandles(
+        const handles: Uint8Array[] = computeHandles(
           ciphertext,
           bits,
           aclContractAddress,
           chainId,
           currentCiphertextVersion(),
         );
+
         // Note that the hex strings returned by the relayer do have have the 0x prefix
         if (json.response.handles && json.response.handles.length > 0) {
           const responseHandles = json.response.handles.map(fromHexString);
@@ -206,7 +209,8 @@ export const createRelayerEncryptedInput =
             }
           }
         }
-        const signatures = json.response.signatures;
+
+        const signatures: string[] = json.response.signatures;
 
         // verify signatures for inputs:
         const domain = {

--- a/src/relayer/sendEncryption.ts
+++ b/src/relayer/sendEncryption.ts
@@ -9,11 +9,16 @@ import { EncryptionTypes } from '../sdk/encryptionTypes';
 import { computeHandles } from './handles';
 import { ethers } from 'ethers';
 import { TFHEType } from '../tfheType';
-import { throwRelayerInternalError} from './error';
-import { fetchRelayerJsonRpcPost, RelayerFetchResponseJson, RelayerInputProofPayload } from './fetchRelayer';
+import { throwRelayerInternalError } from './error';
+import {
+  fetchRelayerJsonRpcPost,
+  RelayerFetchResponseJson,
+  RelayerInputProofPayload,
+} from './fetchRelayer';
 
 // Add type checking
-const getAddress = (value: string): `0x${string}` => ethersGetAddress(value) as `0x${string}`;
+const getAddress = (value: string): `0x${string}` =>
+  ethersGetAddress(value) as `0x${string}`;
 
 export const currentCiphertextVersion = () => {
   return 0;
@@ -58,16 +63,19 @@ function isFhevmRelayerInputProofResponse(
   json: RelayerFetchResponseJson,
 ): json is FhevmRelayerInputProofResponse {
   const response = json.response as unknown;
-  if (typeof response !== "object" || response === null) {
+  if (typeof response !== 'object' || response === null) {
     return false;
   }
-  if (!("handles" in response && Array.isArray(response.handles))) {
+  if (!('handles' in response && Array.isArray(response.handles))) {
     return false;
   }
-  if (!("signatures" in response && Array.isArray(response.signatures))) {
+  if (!('signatures' in response && Array.isArray(response.signatures))) {
     return false;
   }
-  return response.signatures.every((s) => typeof s === "string") && response.handles.every((h) => typeof h === "string");
+  return (
+    response.signatures.every((s) => typeof s === 'string') &&
+    response.handles.every((h) => typeof h === 'string')
+  );
 }
 
 export type RelayerEncryptedInputInternal = RelayerEncryptedInput & {
@@ -167,7 +175,7 @@ export const createRelayerEncryptedInput =
       encrypt: async (options?: { apiKey?: string }) => {
         const bits = input.getBits();
         const ciphertext = input.encrypt();
-        
+
         const payload: RelayerInputProofPayload = {
           contractAddress: getAddress(contractAddress),
           userAddress: getAddress(userAddress),
@@ -175,10 +183,15 @@ export const createRelayerEncryptedInput =
           contractChainId: ('0x' + chainId.toString(16)) as `0x${string}`,
         };
 
-        const json = await fetchRelayerJsonRpcPost('INPUT_PROOF', `${relayerUrl}/v1/input-proof`, payload, options);
+        const json = await fetchRelayerJsonRpcPost(
+          'INPUT_PROOF',
+          `${relayerUrl}/v1/input-proof`,
+          payload,
+          options,
+        );
 
         if (!isFhevmRelayerInputProofResponse(json)) {
-          throwRelayerInternalError("INPUT_PROOF", json);
+          throwRelayerInternalError('INPUT_PROOF', json);
         }
 
         const handles: Uint8Array[] = computeHandles(

--- a/src/relayer/userDecrypt.test.ts
+++ b/src/relayer/userDecrypt.test.ts
@@ -1,40 +1,209 @@
 import { userDecryptRequest } from './userDecrypt';
 import fetchMock from '@fetch-mock/core';
 import { ethers } from 'ethers';
+import { fetchRelayerJsonRpcPost, RelayerUserDecryptPayload } from './fetchRelayer';
+import { getErrorCause, getErrorCauseErrorMessage } from './error';
 
-// fetchMock.mockGlobal();
+const RELAYER_URL: string = 'https://test-relayer.net';
+const RELAYER_USER_DECRYPT_URL= `${RELAYER_URL}/v1/user-decrypt`;
 
-fetchMock.post('https://test-relayer.net/v1/user-decrypt', {
-  status: 'success',
-  response: {},
-});
-
-// const userKeypair = {
-//   publicKey:
-//     '0x2000000000000000f3efe739bc5c1f3ecc75ef238bb281358b6ad60a77a68b67888d8802c53e1c59',
-//   privateKey:
-//     '0x20000000000000001c0922c8007e42e2c5f1e6d3221c03703c868cf17636724fe43fb49383a4dfe4',
-// };
+const dummyRelayerUserDecryptPayload: RelayerUserDecryptPayload = {
+  handleContractPairs: [
+    {
+      handle:
+        '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      contractAddress: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    },
+  ],
+  requestValidity: {
+    startTimestamp: '1234',
+    durationDays: '7',
+  },
+  contractsChainId: '31337',
+  contractAddresses: ['0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'],
+  userAddress: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+  signature: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+  publicKey: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+};
 
 describe('userDecrypt', () => {
+  beforeEach(() => {
+    fetchMock.removeRoutes();
+  });
+
   it('get user decryption for handle', async () => {
+    fetchMock.post(RELAYER_USER_DECRYPT_URL, {
+      status: 'success',
+    });
+
     userDecryptRequest(
       [],
       54321,
       9000,
       '0x8ba1f109551bd432803012645ac136ddd64dba72',
       '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
-      'https://test-relayer.net/',
+      `${RELAYER_URL}/`,
       new ethers.JsonRpcProvider('https://devnet.zama.ai'),
     );
-    // const result = await userDecrypt(
-    //   BigInt(3333),
-    //   userKeypair.privateKey,
-    //   userKeypair.publicKey,
-    //   '0xccc',
-    //   '0x8ba1f109551bd432803012645ac136ddd64dba72',
-    //   '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
-    // );
-    // expect(result.toString()).toBe('10');
+  });
+});
+
+describe('fetchRelayerUserDecrypt', () => {
+  beforeEach(() => {
+    fetchMock.removeRoutes();
+  });
+
+  it('error: response.ok === false', async () => {
+    const response = new Response('Forbidden', {
+      status: 403,
+      statusText: 'Forbidden',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+
+    fetchMock.postOnce(RELAYER_USER_DECRYPT_URL, response);
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'USER_DECRYPT',
+        RELAYER_USER_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        'Error: User decrypt failed: relayer respond with HTTP code 403',
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_FETCH_ERROR',
+        operation: 'USER_DECRYPT',
+        status: 403,
+        statusText: 'Forbidden',
+        url: RELAYER_USER_DECRYPT_URL,
+      });
+    }
+  });
+
+  it('error: response.status === 429', async () => {
+    const response = new Response('Rate Limit', {
+      status: 429,
+      statusText: 'Rate Limit',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+
+    fetchMock.postOnce(RELAYER_USER_DECRYPT_URL, response);
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'USER_DECRYPT',
+        RELAYER_USER_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        'Error: Relayer rate limit exceeded: Please wait and try again later.',
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_FETCH_ERROR',
+        operation: 'USER_DECRYPT',
+        status: 429,
+        statusText: 'Rate Limit',
+        url: RELAYER_USER_DECRYPT_URL,
+      });
+    }
+  });
+
+  it('error: fetch throws an error', async () => {
+    const errorToThrow = new Error();
+    fetchMock.postOnce(RELAYER_USER_DECRYPT_URL, {
+      throws: errorToThrow,
+    });
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'USER_DECRYPT',
+        RELAYER_USER_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        "Error: User decrypt failed: Relayer didn't respond",
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_UNKNOWN_ERROR',
+        operation: 'USER_DECRYPT',
+        error: errorToThrow,
+      });
+    }
+  });
+
+  it('error: no json', async () => {
+    fetchMock.postOnce(RELAYER_USER_DECRYPT_URL, () => {
+      return 'DeadBeef';
+    });
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'USER_DECRYPT',
+        RELAYER_USER_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        "Error: User decrypt failed: Relayer didn't return a JSON",
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_NO_JSON_ERROR',
+        operation: 'USER_DECRYPT',
+        error: new Error(),
+      });
+      expect(String(getErrorCauseErrorMessage(e))).toBe(
+        'Unexpected token \'D\', "DeadBeef" is not valid JSON',
+      );
+    }
+  });
+
+  it('error: unexpected json', async () => {
+    fetchMock.postOnce(RELAYER_USER_DECRYPT_URL, {
+      status: 'failure',
+      dummy: 'This is a dummy error',
+    });
+
+    try {
+      await fetchRelayerJsonRpcPost(
+        'USER_DECRYPT',
+        RELAYER_USER_DECRYPT_URL,
+        dummyRelayerUserDecryptPayload,
+      );
+    } catch (e) {
+      expect(String(e)).toBe(
+        'Error: User decrypt failed: Relayer returned an unexpected JSON response',
+      );
+      const cause = getErrorCause(e);
+      expect(cause).toEqual({
+        code: 'RELAYER_UNEXPECTED_JSON_ERROR',
+        operation: 'USER_DECRYPT',
+        error: new Error(
+          "Unexpected response JSON format: missing 'response' property.",
+        ),
+      });
+    }
+  });
+
+  it('succeeded', async () => {
+    fetchMock.postOnce(RELAYER_USER_DECRYPT_URL, {
+      response: {},
+    });
+    await fetchRelayerJsonRpcPost(
+      'USER_DECRYPT',
+      RELAYER_USER_DECRYPT_URL,
+      dummyRelayerUserDecryptPayload,
+    );
   });
 });

--- a/src/relayer/userDecrypt.test.ts
+++ b/src/relayer/userDecrypt.test.ts
@@ -1,11 +1,14 @@
 import { userDecryptRequest } from './userDecrypt';
 import fetchMock from '@fetch-mock/core';
 import { ethers } from 'ethers';
-import { fetchRelayerJsonRpcPost, RelayerUserDecryptPayload } from './fetchRelayer';
+import {
+  fetchRelayerJsonRpcPost,
+  RelayerUserDecryptPayload,
+} from './fetchRelayer';
 import { getErrorCause, getErrorCauseErrorMessage } from './error';
 
 const RELAYER_URL: string = 'https://test-relayer.net';
-const RELAYER_USER_DECRYPT_URL= `${RELAYER_URL}/v1/user-decrypt`;
+const RELAYER_USER_DECRYPT_URL = `${RELAYER_URL}/v1/user-decrypt`;
 
 const dummyRelayerUserDecryptPayload: RelayerUserDecryptPayload = {
   handleContractPairs: [

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -1,10 +1,15 @@
 import { bytesToBigInt, fromHexString, toHexString } from '../utils';
 import { ethers, getAddress as ethersGetAddress } from 'ethers';
 import { DecryptedResults, checkEncryptedBits } from './decryptUtils';
-import { fetchRelayerJsonRpcPost, HandleContractPairRelayer, RelayerUserDecryptPayload } from './fetchRelayer';
+import {
+  fetchRelayerJsonRpcPost,
+  HandleContractPairRelayer,
+  RelayerUserDecryptPayload,
+} from './fetchRelayer';
 
 // Add type checking
-const getAddress = (value: string): `0x${string}` => ethersGetAddress(value) as `0x${string}`;
+const getAddress = (value: string): `0x${string}` =>
+  ethersGetAddress(value) as `0x${string}`;
 
 const aclABI = [
   'function persistAllowed(bytes32 handle, address account) view returns (bool)',
@@ -94,7 +99,7 @@ export const userDecryptRequest =
     aclContractAddress: string,
     relayerUrl: string,
     provider: ethers.JsonRpcProvider | ethers.BrowserProvider,
-    options?: { apiKey?: string }
+    options?: { apiKey?: string },
   ) =>
   async (
     _handles: HandleContractPair[],
@@ -183,7 +188,7 @@ export const userDecryptRequest =
       'USER_DECRYPT',
       `${relayerUrl}/v1/user-decrypt`,
       payloadForRequest,
-      options
+      options,
     );
 
     // assume the KMS Signers have the correct order

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,13 +18,16 @@ export const fromHexString = (hexString: string): Uint8Array => {
   return Uint8Array.from(arr.map((byte) => parseInt(byte, 16)));
 };
 
-export const toHexString = (bytes: Uint8Array, with0x = false) =>
-  `${with0x ? '0x' : ''}${bytes.reduce(
+export function toHexString(bytes: Uint8Array, with0x: true): `0x${string}`;
+export function toHexString(bytes: Uint8Array, with0x?: false): string;
+export function toHexString(bytes: Uint8Array, with0x = false): string {
+  return `${with0x ? '0x' : ''}${bytes.reduce(
     (str, byte) => str + byte.toString(16).padStart(2, '0'),
     '',
   )}`;
+}
 
-export const bytesToHex = function (byteArray: Uint8Array): string {
+export const bytesToHex = function (byteArray: Uint8Array): `0x${string}` {
   if (!byteArray || byteArray?.length === 0) {
     return '0x0';
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -56,8 +56,10 @@ export {
   generateKeypair,
   createEIP712,
   EIP712,
-  SepoliaConfig,
   EIP712Type,
+  SepoliaConfig,
+  getErrorCauseCode,
+  getErrorCauseStatus
 } from './index';
-
+export { FhevmInstanceConfig } from './config';
 export { initSDK } from './init';

--- a/src/web.ts
+++ b/src/web.ts
@@ -59,7 +59,7 @@ export {
   EIP712Type,
   SepoliaConfig,
   getErrorCauseCode,
-  getErrorCauseStatus
+  getErrorCauseStatus,
 } from './index';
 export { FhevmInstanceConfig } from './config';
 export { initSDK } from './init';


### PR DESCRIPTION
- Add access to relayer error code 
- Add access to relayer fetch error  status
- Add getErrorCauseCode() + getErrorCauseStatus()
- Improve typings
- Add fetch error testing
- Isolate relayer fetch calls 
- Common relayer fetch error management
- Centralize relayer fetch error messages
- Make sure Payloads are up-to-date with relayer backend.
- Make sure Responses are up-to-date with relayer backend.