### PR TITLE
chore: promote to 0.2.0 stable release + audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.2.0-6",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zama-fhe/relayer-sdk",
-      "version": "0.2.0-6",
+      "version": "0.2.0",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",
@@ -14,9 +14,9 @@
         "fetch-retry": "^6.0.0",
         "keccak": "^3.0.4",
         "node-tfhe": "1.3.0",
-        "node-tkms": "0.11.0-26",
+        "node-tkms": "^0.11.0",
         "tfhe": "1.3.0",
-        "tkms": "0.11.0-26",
+        "tkms": "^0.11.0",
         "wasm-feature-detect": "^1.8.0"
       },
       "bin": {
@@ -57,7 +57,7 @@
         "typescript": "5.8.3",
         "vite": "7.0.5",
         "vite-plugin-node-polyfills": "0.24.0",
-        "vite-plugin-static-copy": "3.1.1"
+        "vite-plugin-static-copy": "^3.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -4228,13 +4228,17 @@
       }
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -4892,15 +4896,16 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5371,13 +5376,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -7938,9 +7946,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/node-tkms": {
-      "version": "0.11.0-26",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-26.tgz",
-      "integrity": "sha512-2sw2//2u1PjgW+CxGDrzVJlEmUDYDby51aksKpwGO/2t18sYihthWJtCBAZn+jqR5hSnzE4GfWPl6MvyaqhieA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0.tgz",
+      "integrity": "sha512-Wxm0ZWZBEPzdjfjEPYwRZXX8jFMi3gZ03vQB4GretEaH3lZWZt5eUiWh5yjIhg5BdEyg/ikGs8CSR87mMhKSAw==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/normalize-path": {
@@ -9004,16 +9012,24 @@
       "license": "MIT"
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shebang-command": {
@@ -9560,9 +9576,9 @@
       }
     },
     "node_modules/tkms": {
-      "version": "0.11.0-26",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-26.tgz",
-      "integrity": "sha512-eVOcAFlJj6GI9XmADp9CUYQ0Wpby+Ral2v0RFjSIZA5ovvlYiadazoI+h96lJ4byCqKWUqngZvnizQBnoX3+Uw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0.tgz",
+      "integrity": "sha512-mDXsbg80Z4mTuZIlxbiw6UmklEYSajlWwGxtLqOeBuzSekPG2coDOq8RKM80g/REk1r78ocRk9YuctbG3PjJgw==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/tmpl": {
@@ -10130,9 +10146,9 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.1.tgz",
-      "integrity": "sha512-oR53SkL5cX4KT1t18E/xU50vJDo0N8oaHza4EMk0Fm+2/u6nQivxavOfrDk3udWj+dizRizB/QnBvJOOQrTTAQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.2.tgz",
+      "integrity": "sha512-aVmYOzptLVOI2b1jL+cmkF7O6uhRv1u5fvOkQgbohWZp2CbR22kn9ZqkCUIt9umKF7UhdbsEpshn1rf4720QFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13335,13 +13351,13 @@
       "dev": true
     },
     "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
       }
     },
     "cjs-module-lexer": {
@@ -13846,14 +13862,15 @@
       }
     },
     "es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "requires": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       }
     },
     "es-to-primitive": {
@@ -14199,13 +14216,15 @@
       }
     },
     "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       }
     },
@@ -15967,9 +15986,9 @@
       "integrity": "sha512-BhqHFH1sFp9bziPfar2MqtZI1NT+fsqt6w+q6l1bUFn7ENTwGbjZqZIPGuPKxgnWF6iqMhwVG5IYpKpAwil6oA=="
     },
     "node-tkms": {
-      "version": "0.11.0-26",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-26.tgz",
-      "integrity": "sha512-2sw2//2u1PjgW+CxGDrzVJlEmUDYDby51aksKpwGO/2t18sYihthWJtCBAZn+jqR5hSnzE4GfWPl6MvyaqhieA=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0.tgz",
+      "integrity": "sha512-Wxm0ZWZBEPzdjfjEPYwRZXX8jFMi3gZ03vQB4GretEaH3lZWZt5eUiWh5yjIhg5BdEyg/ikGs8CSR87mMhKSAw=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -16693,13 +16712,14 @@
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       }
     },
     "shebang-command": {
@@ -17070,9 +17090,9 @@
       }
     },
     "tkms": {
-      "version": "0.11.0-26",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-26.tgz",
-      "integrity": "sha512-eVOcAFlJj6GI9XmADp9CUYQ0Wpby+Ral2v0RFjSIZA5ovvlYiadazoI+h96lJ4byCqKWUqngZvnizQBnoX3+Uw=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0.tgz",
+      "integrity": "sha512-mDXsbg80Z4mTuZIlxbiw6UmklEYSajlWwGxtLqOeBuzSekPG2coDOq8RKM80g/REk1r78ocRk9YuctbG3PjJgw=="
     },
     "tmpl": {
       "version": "1.0.5",
@@ -17428,9 +17448,9 @@
       }
     },
     "vite-plugin-static-copy": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.1.tgz",
-      "integrity": "sha512-oR53SkL5cX4KT1t18E/xU50vJDo0N8oaHza4EMk0Fm+2/u6nQivxavOfrDk3udWj+dizRizB/QnBvJOOQrTTAQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.2.tgz",
+      "integrity": "sha512-aVmYOzptLVOI2b1jL+cmkF7O6uhRv1u5fvOkQgbohWZp2CbR22kn9ZqkCUIt9umKF7UhdbsEpshn1rf4720QFg==",
       "dev": true,
       "requires": {
         "chokidar": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.2.0-7",
+  "version": "0.2.0",
   "description": "fhevm Relayer SDK",
   "main": "lib/node.js",
   "types": "lib/node.d.ts",
@@ -61,15 +61,15 @@
     "ethers": "^6.15.0",
     "fetch-retry": "^6.0.0",
     "keccak": "^3.0.4",
-    "wasm-feature-detect": "^1.8.0",
     "node-tfhe": "1.3.0",
+    "node-tkms": "^0.11.0",
     "tfhe": "1.3.0",
-    "node-tkms": "0.11.0-26",
-    "tkms": "0.11.0-26"
+    "tkms": "^0.11.0",
+    "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {
-    "@fetch-mock/jest": "0.2.16",
     "@fetch-mock/core": "0.7.1",
+    "@fetch-mock/jest": "0.2.16",
     "@jest/globals": "30.0.4",
     "@microsoft/api-extractor": "7.52.8",
     "@rollup/plugin-alias": "5.1.1",
@@ -102,6 +102,6 @@
     "typescript": "5.8.3",
     "vite": "7.0.5",
     "vite-plugin-node-polyfills": "0.24.0",
-    "vite-plugin-static-copy": "3.1.1"
+    "vite-plugin-static-copy": "^3.1.2"
   }
 }


### PR DESCRIPTION
DO NOT MERGE UNTIL `tkms` and `node-tkms` dependencies are stable.