### PR TITLE
chore: versions tkms v0.12.0, tfhe v1.4.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "ethers": "^6.15.0",
         "fetch-retry": "^6.0.0",
         "keccak": "^3.0.4",
-        "node-tfhe": "1.3.0",
-        "node-tkms": "^0.11.0",
-        "tfhe": "1.3.0",
-        "tkms": "^0.11.0",
+        "node-tfhe": "1.4.0-alpha.3",
+        "node-tkms": "^0.12.0",
+        "tfhe": "1.4.0-alpha.3",
+        "tkms": "^0.12.0",
         "wasm-feature-detect": "^1.8.0"
       },
       "bin": {
@@ -7940,15 +7940,15 @@
       "license": "MIT"
     },
     "node_modules/node-tfhe": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.3.0.tgz",
-      "integrity": "sha512-BhqHFH1sFp9bziPfar2MqtZI1NT+fsqt6w+q6l1bUFn7ENTwGbjZqZIPGuPKxgnWF6iqMhwVG5IYpKpAwil6oA==",
+      "version": "1.4.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.4.0-alpha.3.tgz",
+      "integrity": "sha512-oTcWL0OFA6t6BhScmDiGQ3VA8tU8T3EXCzIzpNxQxcuJDgQtiUF5CV6dgJLOrpWck4KCp1Bo/xLhv07uwn3q6Q==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/node-tkms": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0.tgz",
-      "integrity": "sha512-Wxm0ZWZBEPzdjfjEPYwRZXX8jFMi3gZ03vQB4GretEaH3lZWZt5eUiWh5yjIhg5BdEyg/ikGs8CSR87mMhKSAw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.12.0.tgz",
+      "integrity": "sha512-XIVFDOYDQXchW3fDPFKbekg/azQacn55FW2P2lFz0Q3kerRo6u6hJKsZuBSQQ0iz8iBZF197TFqEkxMicFff0A==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/normalize-path": {
@@ -9512,9 +9512,9 @@
       }
     },
     "node_modules/tfhe": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tfhe/-/tfhe-1.3.0.tgz",
-      "integrity": "sha512-SYySiMB/hCPJmy3K8RliVYCN4mV/p5+EJozaYfXTS0UEl3aS+1b71XqGfI1KDucYHelVS1iWgF7+uO2wNqQQ/g==",
+      "version": "1.4.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/tfhe/-/tfhe-1.4.0-alpha.3.tgz",
+      "integrity": "sha512-xdla7hi2WzLFIdAx2/ihRZ/bKlKcgDDabTJGtoqp1E5oqhLM1PzTXsJE0p7tW8+ebrvxiMGfbgMAWnU3f2ZAIQ==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/timers-browserify": {
@@ -9576,9 +9576,9 @@
       }
     },
     "node_modules/tkms": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0.tgz",
-      "integrity": "sha512-mDXsbg80Z4mTuZIlxbiw6UmklEYSajlWwGxtLqOeBuzSekPG2coDOq8RKM80g/REk1r78ocRk9YuctbG3PjJgw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.12.0.tgz",
+      "integrity": "sha512-3JEpetW+hvE+PaYGcI4vPzPihWgEnRl31NGjGCyKJt6duhJyo9EbXE2FUz5UGhow582br9asNb6M/AhJkYOA/A==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/tmpl": {
@@ -15981,14 +15981,14 @@
       }
     },
     "node-tfhe": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.3.0.tgz",
-      "integrity": "sha512-BhqHFH1sFp9bziPfar2MqtZI1NT+fsqt6w+q6l1bUFn7ENTwGbjZqZIPGuPKxgnWF6iqMhwVG5IYpKpAwil6oA=="
+      "version": "1.4.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.4.0-alpha.3.tgz",
+      "integrity": "sha512-oTcWL0OFA6t6BhScmDiGQ3VA8tU8T3EXCzIzpNxQxcuJDgQtiUF5CV6dgJLOrpWck4KCp1Bo/xLhv07uwn3q6Q=="
     },
     "node-tkms": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0.tgz",
-      "integrity": "sha512-Wxm0ZWZBEPzdjfjEPYwRZXX8jFMi3gZ03vQB4GretEaH3lZWZt5eUiWh5yjIhg5BdEyg/ikGs8CSR87mMhKSAw=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.12.0.tgz",
+      "integrity": "sha512-XIVFDOYDQXchW3fDPFKbekg/azQacn55FW2P2lFz0Q3kerRo6u6hJKsZuBSQQ0iz8iBZF197TFqEkxMicFff0A=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -17051,9 +17051,9 @@
       }
     },
     "tfhe": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tfhe/-/tfhe-1.3.0.tgz",
-      "integrity": "sha512-SYySiMB/hCPJmy3K8RliVYCN4mV/p5+EJozaYfXTS0UEl3aS+1b71XqGfI1KDucYHelVS1iWgF7+uO2wNqQQ/g=="
+      "version": "1.4.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/tfhe/-/tfhe-1.4.0-alpha.3.tgz",
+      "integrity": "sha512-xdla7hi2WzLFIdAx2/ihRZ/bKlKcgDDabTJGtoqp1E5oqhLM1PzTXsJE0p7tW8+ebrvxiMGfbgMAWnU3f2ZAIQ=="
     },
     "timers-browserify": {
       "version": "2.0.12",
@@ -17090,9 +17090,9 @@
       }
     },
     "tkms": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0.tgz",
-      "integrity": "sha512-mDXsbg80Z4mTuZIlxbiw6UmklEYSajlWwGxtLqOeBuzSekPG2coDOq8RKM80g/REk1r78ocRk9YuctbG3PjJgw=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.12.0.tgz",
+      "integrity": "sha512-3JEpetW+hvE+PaYGcI4vPzPihWgEnRl31NGjGCyKJt6duhJyo9EbXE2FUz5UGhow582br9asNb6M/AhJkYOA/A=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zama-fhe/relayer-sdk",
-      "version": "0.3.0-1",
+      "version": "0.3.0-2",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "ethers": "^6.15.0",
     "fetch-retry": "^6.0.0",
     "keccak": "^3.0.4",
-    "node-tfhe": "1.3.0",
-    "node-tkms": "^0.11.0",
-    "tfhe": "1.3.0",
-    "tkms": "^0.11.0",
+    "node-tfhe": "1.4.0-alpha.3",
+    "node-tkms": "^0.12.0",
+    "tfhe": "1.4.0-alpha.3",
+    "tkms": "^0.12.0",
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "description": "fhevm Relayer SDK",
   "main": "lib/node.js",
   "types": "lib/node.d.ts",


### PR DESCRIPTION
This bumps `tkms` and `tfhe` to the most recent versions.